### PR TITLE
fix: add gcloud auth header for token rotation call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(name='tap-quickbooks',
           'xmltodict==0.11.0',
           'jsonpath-ng==1.4.3',
           'pytz==2018.4',
-          'attrs==20.2.0'
+          'attrs==20.2.0',
+          'google-api-python-client==2.113.0',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
Should work OK locally too. Token will just be ignored.